### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# 修改nfs-deployment.yaml server path 改成自己nfs 服务器配置
+# 修改storageClass.yaml 改成自己喜欢的名字 修改是否为默认存储  storageclass.kubernetes.io/is-default-class: "true"   # true|false
+# 部署nfs storageClass kubectl apply -f .
+# 测试 能自己创建pvc 并成功写入文件 kubectl apply -f test/.
+# service nfslock start
+# systemctl enable nfslock.service


### PR DESCRIPTION
kind: Deployment
apiVersion: apps/v1
metadata:
   name: nfs-client-provisioner
   namespace: clusterstorage
spec:
   selector:
     matchLabels:
       app: nfs-client-provisioner
   replicas: 1
   strategy:
     type: Recreate
   template:
      metadata:
         labels:
            app: nfs-client-provisioner
      spec:
         serviceAccount: nfs-provisioner
         containers:
            -  name: nfs-client-provisioner
               image: quay.io/external_storage/nfs-client-provisioner:latest
               volumeMounts:
                 -  name: nfs-client-root
                    mountPath:  /persistentvolumes
               env:
                 -  name: PROVISIONER_NAME
                    value: fuseim.pri/ifs
                 -  name: NFS_SERVER
                    value: 192.168.2.220
                 -  name: NFS_PATH
                    value: /apps/data
         volumes:
           - name: nfs-client-root
             nfs:
               server: 192.168.2.220
               path: /apps/data